### PR TITLE
Sync migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,24 @@ Defaults should work for local development.
 
 **5. Create and seed the database**
 
+Copy the `packages/backend/prisma/records.csv.sample` to `packages/backend/prisma/records.csv` or use the sample file as a template to create your own.
+
 ```bash
-# Create the database (based on packages/backend/prisma/schema.prisma)
-yarn db:push
+# Create the database schema (based on the migrations, generated from packages/backend/prisma/schema.prisma)
+yarn migrate:dev
 # Seed the database (packages/backend/prisma/seed.ts)
 yarn db:seed
-# Create the prisma Types
-yarn prisma:generate
 ```
 
-You will need to run those commands again when you change the database schema.
-You can also use `yarn db:reset` to drop the database.
+If you want to update the schema:
+1. Tweak the `packages/backend/prisma/schema.prisma`
+2. Run `yarn db:push`
+3. Repeat 1 & 2 until the schema is ready, and then run `yarn migrate:dev --name <your_update_name>` to create the corresponding migration file.
+
+You can also use `yarn db:reset` to regenerate the schema (you'll lose all the data in the database!).
+
+Note: For PROD enviroments, use `yarn migrate:deploy` (instead of `yarn migrate:dev`) to apply the migrations to the database.
+Eventually we could add the command in the `heroku-postbuild` script in `packages/backend/package.json` to run it automatically on Heroku, but for now we'll run it manually.
 
 **6. Start the backend**
 ```bash

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "db:push": "yarn workspace @catalog/backend db:push",
     "db:reset": "yarn workspace @catalog/backend db:reset",
     "db:seed": "yarn workspace @catalog/backend db:seed",
+    "migrate:dev": "yarn workspace @catalog/backend migrate:dev",
+    "migrate:deploy": "yarn workspace @catalog/backend migrate:deploy",
     "prisma:generate": "yarn workspace @catalog/backend prisma:generate",
     "prisma:studio": "yarn workspace @catalog/backend prisma:studio"
   },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -13,6 +13,7 @@
     "db:reset": "prisma migrate reset --skip-seed",
     "db:seed": "prisma db seed",
     "migrate:dev": "prisma migrate dev",
+    "migrate:deploy": "prisma migrate deploy",
     "prisma:generate": "prisma generate",
     "prisma:studio": "prisma studio",
     "prisma:validate": "prisma validate",

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -1,33 +1,30 @@
-datasource db {
-  provider          = "postgresql"
-  url               = env("POSTGRES_PRISMA_URL") // uses connection pooling
-  directUrl         = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
-  shadowDatabaseUrl = env("POSTGRES_URL_NON_POOLING") // used for migrations
-}
-
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
   previewFeatures = ["fullTextSearch"]
 }
 
-// ToDo. Final fields (enabled/approved) and relations (tags?)
+datasource db {
+  provider  = "postgresql"
+  url       = env("POSTGRES_PRISMA_URL")
+  directUrl = env("POSTGRES_URL_NON_POOLING")
+}
+
 model Record {
-  id           Int       @id @default(autoincrement())
+  id           Int                      @id @default(autoincrement())
   title        String
   content      String
   organization String
-  // ToDo. Should be unique?
   link         String
   date         DateTime?
-  slug         String    @unique
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
-  category     Category? @relation(fields: [categoryId], references: [id])
+  slug         String                   @unique
+  createdAt    DateTime                 @default(now())
+  updatedAt    DateTime                 @updatedAt
   categoryId   Int?
   author       String
-  textSearch       Unsupported("TSVECTOR")?
+  textSearch   Unsupported("tsvector")? @default(dbgenerated("((((((to_tsvector('english'::regconfig, title) || ''::tsvector) || to_tsvector('english'::regconfig, content)) || ''::tsvector) || to_tsvector('simple'::regconfig, organization)) || ''::tsvector) || to_tsvector('simple'::regconfig, author))"))
+  category     Category?                @relation(fields: [categoryId], references: [id])
 
-  @@index([textSearch])
+  @@index([textSearch], map: "Record_search_idx", type: Gin)
 }
 
 model Category {


### PR DESCRIPTION
Since we merged #24 `schema.prisma` was out of sync with the migrations files, so running`prisma migrate dev` was creating a new migration file (removing the the index & the default value) + failing to apply.

What I did:
- Start with an empty database
- `prisma migrate deploy` (to import the existing migration file, without checking the schema)
- `prisma db pull` to introspect the database (it auto-updated the `schema.prisma` file)

With this, everything runs smoothly now! I also updated the README with the new `migrate` instructions. 