### PR TITLE
Fix pagination on search. Page size = 9

### DIFF
--- a/packages/backend/src/routes/records.ts
+++ b/packages/backend/src/routes/records.ts
@@ -4,7 +4,7 @@ import express, { Request, Response } from "express";
 const router = express.Router();
 const prisma = new PrismaClient();
 
-const PAGE_SIZE = 10;
+const PAGE_SIZE = 9;
 
 router.get("/", async (req: Request, res: Response) => {
   const currentPage = Number(req.query.page) || 1;

--- a/packages/backend/src/routes/search.ts
+++ b/packages/backend/src/routes/search.ts
@@ -4,7 +4,7 @@ import express, { Request, Response } from "express";
 const router = express.Router();
 const prisma = new PrismaClient();
 
-const PAGE_SIZE = 10;
+const PAGE_SIZE = 9;
 
 router.get("/", async (req: Request, res: Response) => {
   const currentPage = Number(req.query.page) || 1;
@@ -15,21 +15,21 @@ router.get("/", async (req: Request, res: Response) => {
   try {
     const offset = (currentPage - 1) * PAGE_SIZE;
 
-    records = await prisma.$queryRaw`
+    records = (await prisma.$queryRaw`
       SELECT ts_headline('english', CONCAT(title, content, organization, author), websearch_to_tsquery('english', ${q}), 'MaxFragments=2') as headline, id, title, content, organization, link, date, slug, "createdAt", "updatedAt", date, "categoryId", author FROM "Record"
       WHERE
         "textSearch" @@ websearch_to_tsquery('english', ${q})
       ORDER BY ts_rank("textSearch", websearch_to_tsquery('english', ${q})) DESC
       LIMIT ${PAGE_SIZE}
       OFFSET ${offset};
-    ` as any;
+    `) as any;
 
-    const queryCount = await prisma.$queryRaw`
+    const queryCount = (await prisma.$queryRaw`
       SELECT count(id) as count FROM "Record"
       WHERE
         "textSearch" @@ websearch_to_tsquery('english', ${q})
       ;
-    ` as any;
+    `) as any;
 
     totalCount = queryCount[0].count.toString();
 

--- a/packages/frontend/pages/records/index.tsx
+++ b/packages/frontend/pages/records/index.tsx
@@ -8,7 +8,7 @@ interface RecordsProps {
   totalCount: number;
 }
 
-const PAGE_SIZE = 10;
+const PAGE_SIZE = 9;
 
 const RecordsIndex: NextPage<RecordsProps> = ({ records, totalCount }) => {
   const router = useRouter();

--- a/packages/frontend/pages/search.tsx
+++ b/packages/frontend/pages/search.tsx
@@ -9,7 +9,7 @@ interface RecordsProps {
   totalCount: number;
 }
 
-const PAGE_SIZE = 10;
+const PAGE_SIZE = 9;
 
 const Search: NextPage<RecordsProps> = ({ records, totalCount }) => {
   const router = useRouter();
@@ -28,7 +28,7 @@ const Search: NextPage<RecordsProps> = ({ records, totalCount }) => {
   const endIndex = startIndex + PAGE_SIZE;
 
   const goToPage = (page: number) => {
-    router.push(`/records?page=${page}`);
+    router.push(`/search?q=${q}&page=${page}`);
   };
 
   return (


### PR DESCRIPTION
- Fix the pagination when searching
- Changes the page size to 9, so the UI fits better the 3 column display.

Fix #27 

