### PR TITLE
Styling tweaks

### DIFF
--- a/packages/frontend/components/Header.tsx
+++ b/packages/frontend/components/Header.tsx
@@ -11,9 +11,9 @@ export const Header = () => {
   const isMainPage = pathname === "/";
 
   return (
-    <div className="flex justify-between items-center px-16 pt-11 pb-14 bg-accent">
+    <div className="flex justify-between items-center px-12 py-6 bg-accent">
       <span className="font-bold sm:text-xl">
-        <Link href="/" className="flex gap-10 items-center">
+        <Link href="/" className="flex gap-6 items-center">
           <span>
             <Image src="/assets/logo.svg" alt="Logo" width={64} height={64} />
           </span>

--- a/packages/frontend/components/RecordTeaser.tsx
+++ b/packages/frontend/components/RecordTeaser.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+
+export const RecordTeaser = ({ record }: { record: any }) => (
+  <div key={record.id} className="border-t-base-200 border-t-[10px] py-6">
+    <h2 className="text-xl md:text-3xl mb-2">
+      <Link href={`/records/${record.slug}`}>
+        <span className="font-bold">{record.title}</span>
+      </Link>
+    </h2>
+    <p>
+      <span className="text-lg md:text-2xl">{record.organization}</span>
+    </p>
+  </div>
+);

--- a/packages/frontend/components/RecordTeaser.tsx
+++ b/packages/frontend/components/RecordTeaser.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-export const RecordTeaser = ({ record }: { record: any }) => (
+export const RecordTeaser = ({ record, showHeadline = false }: { record: any; showHeadline?: boolean }) => (
   <div key={record.id} className="border-t-base-200 border-t-[10px] py-6">
     <h2 className="text-xl md:text-3xl mb-2">
       <Link href={`/records/${record.slug}`}>
@@ -10,5 +10,10 @@ export const RecordTeaser = ({ record }: { record: any }) => (
     <p>
       <span className="text-lg md:text-2xl">{record.organization}</span>
     </p>
+    {showHeadline && (
+      <p className="mt-4">
+        <span className="italic break-words" dangerouslySetInnerHTML={{ __html: record.headline }}></span>
+      </p>
+    )}
   </div>
 );

--- a/packages/frontend/pages/index.tsx
+++ b/packages/frontend/pages/index.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { GetServerSideProps, NextPage } from "next";
+import { RecordTeaser } from "~~/components/RecordTeaser";
 
 interface RecordsProps {
   // ToDo. Define types (swagger on backend?)
@@ -44,22 +45,13 @@ const Home: NextPage<RecordsProps> = ({ records, totalCount }) => {
       </div>
       <div className="container mx-auto w-[1350px] max-w-[90%] mt-14">
         <div className="mb-12">
-          <Link href="/records" className="font-bold text-4xl link-hover">
+          <Link href="/records" className="font-bold text-2xl link-hover">
             See All records {">"}
           </Link>
         </div>
         <div className="grid md:grid-cols-3 gap-8">
           {records?.slice(0, 6).map(record => (
-            <div key={record.id} className="border-t-base-200 border-t-[10px] py-6">
-              <p className="text-2xl md:text-4xl mb-2">
-                <Link href={`/records/${record.slug}`}>
-                  <span className="font-bold">{record.title}</span>
-                </Link>
-              </p>
-              <p>
-                <span className="text-lg md:text-2xl">{record.organization}</span>
-              </p>
-            </div>
+            <RecordTeaser record={record} />
           ))}
         </div>
       </div>

--- a/packages/frontend/pages/records/[slug].tsx
+++ b/packages/frontend/pages/records/[slug].tsx
@@ -34,7 +34,7 @@ const RecordPage: NextPage<RecordProps> = ({ record }) => {
           </div>
           <div>
             <span className="font-bold">Source:</span>
-            <a className="block link" href={record.link} target="_blank">
+            <a className="block link break-all" href={record.link} target="_blank">
               {record.link}
             </a>
           </div>

--- a/packages/frontend/pages/records/[slug].tsx
+++ b/packages/frontend/pages/records/[slug].tsx
@@ -9,7 +9,7 @@ const RecordPage: NextPage<RecordProps> = ({ record }) => {
   return (
     <div className="container mx-auto w-[1150px] max-w-[90%] mt-14 pb-20 md:pb-44">
       <div className="border-b-200 border-b-[10px] mb-10">
-        <h1 className="font-bold text-2xl md:text-6xl mb-4 leading-none">{record.title}</h1>
+        <h1 className="font-bold text-xl md:text-5xl mb-4 !leading-[1.1]">{record.title}</h1>
         <span className="mb-8 block text-lg md:text-2xl">{record.organization}</span>
       </div>
 

--- a/packages/frontend/pages/records/[slug].tsx
+++ b/packages/frontend/pages/records/[slug].tsx
@@ -5,6 +5,15 @@ interface RecordProps {
   record: any;
 }
 
+const formatDate = (dateString: string) => {
+  const options: Intl.DateTimeFormatOptions = {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  };
+  return new Date(dateString).toLocaleDateString("en-US", options);
+};
+
 const RecordPage: NextPage<RecordProps> = ({ record }) => {
   return (
     <div className="container mx-auto w-[1150px] max-w-[90%] mt-14 pb-20 md:pb-44">
@@ -31,7 +40,7 @@ const RecordPage: NextPage<RecordProps> = ({ record }) => {
           </div>
           <div>
             <span className="font-bold">Date:</span>
-            <span className="block">{record.date}</span>
+            <span className="block">{record.date ? formatDate(record.date) : "-"}</span>
           </div>
           <div>
             <span className="font-bold">Category:</span>

--- a/packages/frontend/pages/records/index.tsx
+++ b/packages/frontend/pages/records/index.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { GetServerSideProps, NextPage } from "next";
+import { RecordTeaser } from "~~/components/RecordTeaser";
 
 interface RecordsProps {
   // ToDo. Define types (swagger on backend?)
@@ -30,16 +31,7 @@ const RecordsIndex: NextPage<RecordsProps> = ({ records, totalCount }) => {
       <div className="container mx-auto w-[1350px] max-w-[90%] mt-14">
         <div className="grid md:grid-cols-3 gap-8">
           {records?.map(record => (
-            <div key={record.id} className="border-t-base-200 border-t-[10px] py-6">
-              <p className="text-2xl md:text-4xl mb-2">
-                <Link href={`/records/${record.slug}`}>
-                  <span className="font-bold">{record.title}</span>
-                </Link>
-              </p>
-              <p>
-                <span className="text-lg md:text-2xl">{record.organization}</span>
-              </p>
-            </div>
+            <RecordTeaser record={record} />
           ))}
         </div>
       </div>

--- a/packages/frontend/pages/search.tsx
+++ b/packages/frontend/pages/search.tsx
@@ -55,7 +55,7 @@ const Search: NextPage<RecordsProps> = ({ records, totalCount }) => {
       <div className="container mx-auto w-[1350px] max-w-[100%]  mt-14">
         <div className="grid md:grid-cols-3 gap-8">
           {records?.map(record => (
-            <RecordTeaser record={record} />
+            <RecordTeaser record={record} showHeadline={true} />
           ))}
         </div>
       </div>

--- a/packages/frontend/pages/search.tsx
+++ b/packages/frontend/pages/search.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { GetServerSideProps, NextPage } from "next";
+import { RecordTeaser } from "~~/components/RecordTeaser";
 
 interface RecordsProps {
   // ToDo. Define types (swagger on backend?)
@@ -54,19 +55,7 @@ const Search: NextPage<RecordsProps> = ({ records, totalCount }) => {
       <div className="container mx-auto w-[1350px] max-w-[100%]  mt-14">
         <div className="grid md:grid-cols-3 gap-8">
           {records?.map(record => (
-            <div key={record.id} className="border-t-base-200 border-t-[10px] py-6">
-              <p className="text-2xl md:text-4xl mb-2">
-                <Link href={`/records/${record.slug}`}>
-                  <span className="font-bold">{record.title}</span>
-                </Link>
-              </p>
-              <p>
-                <span className="text-lg md:text-2xl">{record.organization}</span>
-              </p>
-              <p className="mt-4">
-                <span className="italic break-words" dangerouslySetInnerHTML={{ __html: record.headline }}></span>
-              </p>
-            </div>
+            <RecordTeaser record={record} />
           ))}
         </div>
       </div>

--- a/packages/frontend/styles/globals.css
+++ b/packages/frontend/styles/globals.css
@@ -26,6 +26,15 @@ h6 {
   letter-spacing: 0.7px;
 }
 
+.record-view-mode-full h1,
+.record-view-mode-full h2,
+.record-view-mode-full h3,
+.record-view-mode-full h4,
+.record-view-mode-full h5,
+.record-view-mode-full h6 {
+  font-family: var(--font-inter);
+}
+
 .font-heading {
   letter-spacing: 0.7px;
 }


### PR DESCRIPTION
Some specific details (exact size/px) still missing from #45 but created this PR with some tweaks

> Reduce Font Size: Only Header / H1 size (will update with exact size)

Changed the size of the H1 record title on the record detail page. And tweaked the line-height a bit too. Feel free to suggest tweaks!

![image](https://github.com/amy-jung/collectivedaoarchives.catalog/assets/2486142/7a26fd6d-3285-4b1f-8dae-310f032e2deb)


> Dates on Record Detail: Month (written out), Day, Year (ie. January 10, 2023) Linked to https://github.com/amy-jung/collectivedaoarchives.catalog/issues/35

Fixed!

![image](https://github.com/amy-jung/collectivedaoarchives.catalog/assets/2486142/4fb0ae5d-ae9c-476a-8150-ebec0e2857f2)

> Typography: “Display”(Title of Records Page and Titles in Home Page) should be “Cooper Hewitt bold” and the rest should be “Inter”. All html text in Records long form content should be “Inter”. Headers of titles in home page and results page should be “Cooper Hewitt bold”.

- Changed font to Cooper on records title (teaser)
- Decreased the font size a bit
- (dev) Abstracted the "record teaser" to a component
![image](https://github.com/amy-jung/collectivedaoarchives.catalog/assets/2486142/3a0a91ae-b8e1-43d5-a02a-b7478f0524b8)

- Font is now Inter for all the record content HTML.
- Fixed the overflowing link from #35

>Reduce Padding and overall size of Site Top Header (will update with exact px)

Tweaked the spacing a bit in the header (external padding, gap between logo / name)

----

cc @amy-jung: don't hesitate to suggest any tweaks here!

Fixes #45 #35 